### PR TITLE
🚢 Ship Analyzers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,6 @@ jobs:
       - name: Pack and push
         run: |
             dotnet pack -c Release
-            dotnet nuget push ./src/bin/Release/Murder.Bang.*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate --api-key ${NUGET_TOKEN}
+            dotnet nuget push ./src/**/bin/Release/Murder.Bang.*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate --api-key ${NUGET_TOKEN}
         env:
           NUGET_TOKEN: ${{secrets.NUGET_TOKEN}}

--- a/src/Bang.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Bang.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,17 @@
+### New Rules
+
+| Rule ID  | Category | Severity | Notes                                     |
+|----------|----------|----------|-------------------------------------------|
+| BANG0001 | Usage    | Error    | Classes cannot be components.             |
+| BANG0002 | Usage    | Error    | Components must be declared as readonly.  |
+| BANG1001 | Usage    | Error    | System requires FilterAttribute.          |
+| BANG1002 | Usage    | Warning  | System requires MessagerAttribute.        |
+| BANG1003 | Usage    | Warning  | System requires WatchAttribute.           |
+| BANG1004 | Usage    | Warning  | System does not use MessagerAttribute.    |
+| BANG1005 | Usage    | Info     | System does not use WatchAttribute.       |
+| BANG2001 | Usage    | Error    | Filter attribute expects only components. |
+| BANG2002 | Usage    | Error    | Filter attribute expects only messages.   |
+| BANG2003 | Usage    | Error    | Messager attribute expects only messages. |
+| BANG2004 | Usage    | Error    | Watch attribute expects only components.  |
+| BANG3001 | Usage    | Error    | Classes cannot be messages.               |
+| BANG3002 | Usage    | Warning  | Messages must be declared as readonly.    |

--- a/src/Bang.Analyzers/Bang.Analyzers.csproj
+++ b/src/Bang.Analyzers/Bang.Analyzers.csproj
@@ -1,12 +1,44 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        <!-- Project configuration. -->
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>11</LangVersion>
-        <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+        
+        <!-- NuGet package configuration. -->
+        <RootNamespace>Bang</RootNamespace> <!-- This is necessary because of the way things are packed.-->
+        <AssemblyName>Bang.Analyzers</AssemblyName>
+        <NoPackageAnalysis>true</NoPackageAnalysis>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <DevelopmentDependency>true</DevelopmentDependency>
+        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+        <Description>Source code analyzers for Bang</Description>
+
+        <PackageId>Murder.Bang.Analyzers</PackageId>
+        <PackageVersion>0.0.1-alpha</PackageVersion>
+        <Authors>Murder Authors</Authors>
+        <Company>Murder Engine</Company>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+
+        <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        
     </PropertyGroup>
+    <ItemGroup>
+        <None Include="..\..\LICENSE" Pack="true" PackagePath="" Visible="false"/>
+
+        <!-- Include .dll in the correct folder. -->
+        <None Include="$(OutputPath)/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+
+        <!-- Files that keep track of what analyzer are/aren't included in releases. -->
+        <None Remove="AnalyzerReleases.Shipped.md" />
+        <None Remove="AnalyzerReleases.Unshipped.md" />
+<!--        <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />-->
+<!--        <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />-->
+    </ItemGroup>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">

--- a/src/Bang.Analyzers/Bang.Analyzers.csproj
+++ b/src/Bang.Analyzers/Bang.Analyzers.csproj
@@ -35,8 +35,8 @@
         <!-- Files that keep track of what analyzer are/aren't included in releases. -->
         <None Remove="AnalyzerReleases.Shipped.md" />
         <None Remove="AnalyzerReleases.Unshipped.md" />
-<!--        <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />-->
-<!--        <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />-->
+        <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+        <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Bang.Analyzers/DiagnosticIds.cs
+++ b/src/Bang.Analyzers/DiagnosticIds.cs
@@ -54,25 +54,25 @@ public static class Diagnostics
     {
         public static class NonComponentsOnFilterAttribute
         {
-            public const string Id = "BANG3001";
+            public const string Id = "BANG2001";
             public const string Message = "Filter attribute expects only components.";
         }
 
         public static class NonMessagesOnMessagerFilterAttribute
         {
-            public const string Id = "BANG3002";
+            public const string Id = "BANG2002";
             public const string Message = "Filter attribute expects only messages.";
         }
 
         public static class NonMessagesOnMessagerAttribute
         {
-            public const string Id = "BANG3003";
+            public const string Id = "BANG2003";
             public const string Message = "Messager attribute expects only messages.";
         }
 
         public static class NonComponentsOnWatchAttribute
         {
-            public const string Id = "BANG3004";
+            public const string Id = "BANG2004";
             public const string Message = "Watch attribute expects only components.";
         }
     }
@@ -81,13 +81,13 @@ public static class Diagnostics
     {
         public static class ClassesCannotBeMessages
         {
-            public const string Id = "BANG4001";
+            public const string Id = "BANG3001";
             public const string Message = "Classes cannot be messages.";
         }
 
         public static class MessagesMustBeReadonly
         {
-            public const string Id = "BANG4002";
+            public const string Id = "BANG3002";
             public const string Message = "Messages must be declared as readonly.";
         }
     }

--- a/src/Bang/Bang.csproj
+++ b/src/Bang/Bang.csproj
@@ -33,8 +33,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <None Include="..\LICENSE" Pack="true" PackagePath="" Visible="false"/>
-    <None Include="..\README.md" Pack="true" PackagePath="" Visible="false" />
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="" Visible="false"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
This:

- Changes the Analyzer project so that the correct .dlls get put in the correct places, thus making the final nupkg behave like an analyzer
- Updates Bang's diagnostic id table and table of shipped analyzers
- Update the relative path in the script that uploads packages to NuGet so that they are all included (given the recent directory changes, not even Bang.dll was being included)