### PR TITLE
📦 Fix packing for analyzers

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,6 +74,7 @@ jobs:
   
       - name: Pack and push
         run: |
+            dotnet build -c Release
             dotnet pack -c Release
             dotnet nuget push ./src/**/bin/Release/Murder.Bang.*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate --api-key ${NUGET_TOKEN}
         env:


### PR DESCRIPTION
Because the analyzers package requires a reference of the very .dll it generates to be placed inside a specific folder, we need to run a build before packing