### PR TITLE
🐛 System attribute check fixes

### DIFF
--- a/src/Bang.Analyzers.Tests/Analyzers/SystemAnalyzerTests.cs
+++ b/src/Bang.Analyzers.Tests/Analyzers/SystemAnalyzerTests.cs
@@ -334,4 +334,88 @@ public class IncorrectSystem : ISystem
 
         await Verify.VerifyAnalyzerAsync(source, expected);
     }
+
+    [TestMethod(displayName: "Systems that inherit from an annotated system do not need the Filter annotation.")]
+    public async Task SystemWithAnnotatedSubclass()
+    {
+        const string source = @"
+using Bang;
+using Bang.Components;
+using Bang.Contexts;
+using Bang.Entities;
+using Bang.Systems;
+
+namespace BangAnalyzerTestNamespace;
+
+public readonly record struct CorrectComponent : IComponent;
+
+[Filter(ContextAccessorKind.Read, typeof(CorrectComponent))]
+public class BaseSystem : ISystem
+{
+}
+
+public class InheritingSystem : BaseSystem
+{
+}";
+
+        await Verify.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod(displayName: "Reactive systems that inherit from an annotated system do not need the Filter or Watch annotation.")]
+    public async Task ReactiveSystemWithAnnotatedSubclass()
+    {
+        const string source = @"
+using Bang;
+using Bang.Components;
+using Bang.Contexts;
+using Bang.Entities;
+using Bang.Systems;
+using System.Collections.Immutable;
+
+namespace BangAnalyzerTestNamespace;
+
+public readonly record struct CorrectComponent : IComponent;
+
+[Watch(typeof(CorrectComponent))]
+public class BaseSystem : IReactiveSystem
+{
+    public void OnAdded(World world, ImmutableArray<Entity> entities) { }
+    public void OnRemoved(World world, ImmutableArray<Entity> entities) { }
+    public void OnModified(World world, ImmutableArray<Entity> entities) { }
+}
+
+public class InheritingSystem : BaseSystem
+{
+}";
+
+        await Verify.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod(displayName: "Messager Systems that inherit from an annotated system do not need the Filter or Message annotation.")]
+    public async Task MessagerSystemWithAnnotatedSubclass()
+    {
+        const string source = @"
+using System.Collections.Immutable;
+using Bang;
+using Bang.Components;
+using Bang.Contexts;
+using Bang.Entities;
+using Bang.Systems;
+
+namespace BangAnalyzerTestNamespace;
+
+public readonly record struct CorrectMessage : IMessage;
+
+[Messager(typeof(CorrectMessage))]
+public class BaseSystem : IMessagerSystem
+{
+    public void OnMessage(World world, Entity entity, IMessage message) { }
+}
+
+public class InheritingSystem : BaseSystem
+{
+}";
+
+        await Verify.VerifyAnalyzerAsync(source);
+    }
 }

--- a/src/Bang.Analyzers.Tests/Analyzers/SystemAnalyzerTests.cs
+++ b/src/Bang.Analyzers.Tests/Analyzers/SystemAnalyzerTests.cs
@@ -2,7 +2,7 @@ using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Bang.Analyzers.Tests;
+namespace Bang.Analyzers.Tests.Analyzers;
 
 using Verify = BangAnalyzerVerifier<SystemAnalyzer>;
 
@@ -414,6 +414,75 @@ public class BaseSystem : IMessagerSystem
 
 public class InheritingSystem : BaseSystem
 {
+}";
+
+        await Verify.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod(displayName: "Abstract systems do not need the Filter annotation.")]
+    public async Task AbstractSystem()
+    {
+        const string source = @"
+using Bang;
+using Bang.Components;
+using Bang.Contexts;
+using Bang.Entities;
+using Bang.Systems;
+
+namespace BangAnalyzerTestNamespace;
+
+public readonly record struct CorrectComponent : IComponent;
+
+public abstract class System : ISystem
+{
+}";
+
+        await Verify.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod(displayName: "Abstract reactive systems do not need the Filter or Watch annotation.")]
+    public async Task AbstractReactiveSystem()
+    {
+        const string source = @"
+using Bang;
+using Bang.Components;
+using Bang.Contexts;
+using Bang.Entities;
+using Bang.Systems;
+using System.Collections.Immutable;
+
+namespace BangAnalyzerTestNamespace;
+
+public readonly record struct CorrectComponent : IComponent;
+
+public abstract class AbstractSystem : IReactiveSystem
+{
+    public void OnAdded(World world, ImmutableArray<Entity> entities) { }
+    public void OnRemoved(World world, ImmutableArray<Entity> entities) { }
+    public void OnModified(World world, ImmutableArray<Entity> entities) { }
+}";
+
+        await Verify.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod(displayName: "Abstract messager Systems do not need the Filter or Message annotation.")]
+    public async Task AbstractMessagerSystem()
+    {
+        const string source = @"
+using System.Collections.Immutable;
+using Bang;
+using Bang.Components;
+using Bang.Contexts;
+using Bang.Entities;
+using Bang.Systems;
+
+namespace BangAnalyzerTestNamespace;
+
+public readonly record struct CorrectMessage : IMessage;
+
+public abstract class AbstractSystem : IMessagerSystem
+{
+    public void OnMessage(World world, Entity entity, IMessage message) { }
 }";
 
         await Verify.VerifyAnalyzerAsync(source);

--- a/src/Bang.Analyzers/Analyzers/SystemAnalyzer.cs
+++ b/src/Bang.Analyzers/Analyzers/SystemAnalyzer.cs
@@ -96,6 +96,10 @@ public sealed class SystemAnalyzer : DiagnosticAnalyzer
         var isSystem = typeSymbol.ImplementsInterface(bangSystemInterface);
         if (!isSystem)
             return;
+        
+        // Abstract types don't need to be annotated and can instead delegate their filters to subclasses.
+        if (typeSymbol.IsAbstract)
+            return;
 
         // IReactiveSystem and IMessagerSystem don't need the filter attribute.
         var filterIsOptional = false;


### PR DESCRIPTION
This fixes a couple of wrong checks in the attribute analyzer, namely:

- We no longer mark systems that have a filter/watch/messager attribute declared in their base types as needing a filter/watch/messager attribute
- We no longer mark abstract systems as needing the mandatory attributes