### PR TITLE
🌎 Add Analyzer for UniqueComponents

### DIFF
--- a/src/Bang.Analyzers.Tests/Analyzers/WorldAnalyzerTests.cs
+++ b/src/Bang.Analyzers.Tests/Analyzers/WorldAnalyzerTests.cs
@@ -1,0 +1,136 @@
+using Bang.Analyzers.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bang.Analyzers.Tests.Analyzers;
+
+using Verify = BangAnalyzerVerifier<WorldAnalyzer>;
+
+[TestClass]
+public sealed class WorldAnalyzerTests
+{
+    [TestMethod(displayName: "Correctly annotated components do not trigger the analyzer.")]
+    public async Task CorrectlyAnnotatedSystemsDoNotTriggerTheAnalyzer()
+    {
+        const string source = @"
+using Bang;
+using Bang.Components;
+using Bang.Contexts;
+using Bang.Entities;
+using Bang.Systems;
+using System;
+using System.Collections.Immutable;
+
+namespace BangAnalyzerTestNamespace;
+
+[Unique]
+public readonly record struct UniqueComponent : IComponent;
+
+[Filter(ContextAccessorKind.Read, typeof(UniqueComponent))]
+public sealed class CorrectSystem : IFixedUpdateSystem
+{
+    public void FixedUpdate(Context context)
+    {
+        var uniqueEntity = context.World.GetUniqueEntity<UniqueComponent>();
+        Console.WriteLine(uniqueEntity);
+    }
+}";
+        await Verify.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod(displayName: "This call should not trigger on other generic methods.")]
+    public async Task NoTriggerOnOtherGenericMethods()
+    {
+        const string source = @"
+using Bang;
+using Bang.Components;
+using Bang.Contexts;
+using Bang.Entities;
+using Bang.Systems;
+using System;
+using System.Linq;
+using System.Collections.Immutable;
+
+namespace BangAnalyzerTestNamespace;
+
+[Unique]
+public readonly record struct UniqueComponent : IComponent;
+
+[Filter(ContextAccessorKind.Read, typeof(UniqueComponent))]
+public sealed class CorrectSystem : IFixedUpdateSystem
+{
+    public void FixedUpdate(Context context)
+    {
+        var list = ImmutableList.Create<int>(1, 2, 3);
+        var first = list.First<int>();
+        System.Console.WriteLine(first);
+    }
+}";
+        await Verify.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod(displayName: "Calling get unique entity with a non-unique component fails.")]
+    public async Task GetUniqueEntityWithANonUniqueComponent()
+    {
+        const string source = @"
+using Bang;
+using Bang.Components;
+using Bang.Contexts;
+using Bang.Entities;
+using Bang.Systems;
+using System;
+using System.Collections.Immutable;
+
+namespace BangAnalyzerTestNamespace;
+
+public readonly record struct UniqueComponent : IComponent;
+
+[Filter(ContextAccessorKind.Read, typeof(UniqueComponent))]
+public sealed class CorrectSystem : IFixedUpdateSystem
+{
+    public void FixedUpdate(Context context)
+    {
+        var uniqueEntity = context.World.GetUniqueEntity<UniqueComponent>();
+        Console.WriteLine(uniqueEntity);
+    }
+}";
+        var expected = Verify.Diagnostic(WorldAnalyzer.MarkUniqueComponentAsUnique)
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithSpan(19, 58, 19, 73);
+
+        await Verify.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [TestMethod(displayName: "Calling get unique entity with a non-unique component fails when world is a variable.")]
+    public async Task GetUniqueEntityWithANonUniqueComponentWorldVar()
+    {
+        const string source = @"
+using Bang;
+using Bang.Components;
+using Bang.Contexts;
+using Bang.Entities;
+using Bang.Systems;
+using System;
+using System.Collections.Immutable;
+
+namespace BangAnalyzerTestNamespace;
+
+public readonly record struct UniqueComponent : IComponent;
+
+[Filter(ContextAccessorKind.Read, typeof(UniqueComponent))]
+public sealed class CorrectSystem : IFixedUpdateSystem
+{
+    public void FixedUpdate(Context context)
+    {
+        var world = context.World;
+        var uniqueComponent = world.GetUnique<UniqueComponent>();
+        Console.WriteLine(uniqueComponent);
+    }
+}";
+        var expected = Verify.Diagnostic(WorldAnalyzer.MarkUniqueComponentAsUnique)
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithSpan(20, 47, 20, 62);
+
+        await Verify.VerifyAnalyzerAsync(source, expected);
+    }
+}

--- a/src/Bang.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Bang.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,11 @@
+## Release 0.0.4
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+BANG4001 | Usage    | Warning  | Component must be annotated with UniqueAttribute.    
+
 ## Release 0.0.3
 
 ### New Rules

--- a/src/Bang.Analyzers/Analyzers/WorldAnalyzer.cs
+++ b/src/Bang.Analyzers/Analyzers/WorldAnalyzer.cs
@@ -1,0 +1,95 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Bang.Analyzers.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class WorldAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor MarkUniqueComponentAsUnique = new(
+        id: Diagnostics.World.MarkUniqueComponentAsUnique.Id,
+        title: nameof(WorldAnalyzer) + "." + nameof(MarkUniqueComponentAsUnique),
+        messageFormat: Diagnostics.World.MarkUniqueComponentAsUnique.Message,
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "When retrieving components using GetUniqueEntity, consider marking that entity as [Unique]."
+    );
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(MarkUniqueComponentAsUnique);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        var syntaxKind = ImmutableArray.Create(SyntaxKind.InvocationExpression);
+
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.RegisterSyntaxNodeAction(Analyze, syntaxKind);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        // Bail if World is not resolvable.
+        var world = context.Compilation.GetTypeByMetadataName(TypeMetadataNames.WorldType);
+        if (world is null)
+            return;
+
+        // Bail if UniqueAttribute is not resolvable.
+        var uniqueAttribute = context.Compilation.GetTypeByMetadataName(TypeMetadataNames.UniqueAttribute);
+        if (uniqueAttribute is null)
+            return;
+
+        var invocationExpressionSyntax = (InvocationExpressionSyntax)context.Node;
+        if (invocationExpressionSyntax.Expression is not MemberAccessExpressionSyntax memberAccessExpression)
+            return;
+
+        // Bail if the methods are not the 4 methods in Bang.World that we are looking for.
+        if (!memberAccessExpression.Name.ToString().Contains("GetUnique"))
+            return;
+
+        // Bail out this call is not for the type Bang.World.
+        var memberAccessNode = memberAccessExpression.ChildNodes().FirstOrDefault();
+        if (memberAccessNode is null)
+            return;
+
+        if (context.SemanticModel.GetTypeInfo(memberAccessNode).Type is not INamedTypeSymbol typeInfo ||
+            !typeInfo.Equals(world, SymbolEqualityComparer.IncludeNullability))
+            return;
+
+        // Bail out if not one of the methods we are verifying 
+
+        // TODO: Bail if not part of za warudo
+        var genericArgument = invocationExpressionSyntax
+            .DescendantNodes()
+            .OfType<GenericNameSyntax>()
+            .FirstOrDefault()
+            ?.TypeArgumentList
+            .Arguments
+            .FirstOrDefault();
+
+        if (genericArgument is null)
+            return;
+
+        if (context.SemanticModel.GetSymbolInfo(genericArgument).Symbol is not ITypeSymbol genericArgumentTypeSymbol)
+            return;
+
+        var hasUniqueAttribute =
+            genericArgumentTypeSymbol
+                .GetAttributes()
+                .Any(a => a.AttributeClass?.Equals(uniqueAttribute, SymbolEqualityComparer.IncludeNullability) ?? false);
+
+        if (hasUniqueAttribute)
+            return;
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                MarkUniqueComponentAsUnique,
+                genericArgument.GetLocation()
+            )
+        );
+    }
+}

--- a/src/Bang.Analyzers/DiagnosticIds.cs
+++ b/src/Bang.Analyzers/DiagnosticIds.cs
@@ -85,4 +85,13 @@ public static class Diagnostics
             public const string Message = "Messages must be declared as readonly";
         }
     }
+
+    public static class World
+    {
+        public static class MarkUniqueComponentAsUnique
+        {
+            public const string Id = "BANG4001";
+            public const string Message = "Trying to get an unique component not marked with the Unique attribute";
+        }
+    }
 }

--- a/src/Bang.Analyzers/TypeMetadataNames.cs
+++ b/src/Bang.Analyzers/TypeMetadataNames.cs
@@ -12,4 +12,7 @@ public static class TypeMetadataNames
     public const string MessageInterface = "Bang.Components.IMessage";
     public const string MessagerSystemInterface = "Bang.Systems.IMessagerSystem";
     public const string MessagerAttribute = "Bang.Systems.MessagerAttribute";
+
+    public const string WorldType = "Bang.World";
+    public const string UniqueAttribute = "Bang.Components.UniqueAttribute";
 }


### PR DESCRIPTION
This analyzer yells at you when you do `context.World.GetUniqueEntity<BlahComponent>()` and `BlahComponent` is not annotated with `Unique`.