### PR TITLE
⚠️ Remove build warnings

### DIFF
--- a/src/Bang.Generator/Templating/Templates.ComponentTypes.cs
+++ b/src/Bang.Generator/Templating/Templates.ComponentTypes.cs
@@ -20,6 +20,10 @@ public static partial class Templates
 
         protected override string ProcessComponent(TypeMetadata.Component metadata)
             => $"""
+                
+                        /// <summary>
+                        /// Unique Id used for the lookup of components with type <see cref="{metadata.FullyQualifiedName}"/>.
+                        /// </summary>
                         public const int {metadata.FriendlyName} = global::Bang.{ParentProjectPrefix}ComponentsLookup.{ParentProjectPrefix}NextLookupId + {metadata.Index};
 
                 """;

--- a/src/Bang.Generator/Templating/Templates.EntityExtensions.cs
+++ b/src/Bang.Generator/Templating/Templates.EntityExtensions.cs
@@ -27,6 +27,9 @@ public static partial class Templates
 
         protected override string ProcessComponent(TypeMetadata.Component metadata) =>
             $"""
+                     /// <summary>
+                     /// Gets a component of type <see cref="{metadata.FullyQualifiedName}"/>.
+                     /// </summary>
                      {(metadata.IsInternal ? "internal" : "public")} static global::{metadata.FullyQualifiedName} Get{metadata.FriendlyName}(this global::Bang.Entities.Entity e)
                          => e.GetComponent<global::{metadata.FullyQualifiedName}>(global::Bang.Entities.{ProjectPrefix}ComponentTypes.{metadata.FriendlyName});
 
@@ -40,6 +43,9 @@ public static partial class Templates
 
         protected override string ProcessComponent(TypeMetadata.Component metadata) =>
             $"""
+                     /// <summary>
+                     /// Checks whether this entity possesses a component of type <see cref="{metadata.FullyQualifiedName}"/> or not.
+                     /// </summary>
                      {(metadata.IsInternal ? "internal" : "public")} static bool Has{metadata.FriendlyName}(this global::Bang.Entities.Entity e)
                          => e.HasComponent(global::Bang.Entities.{ProjectPrefix}ComponentTypes.{metadata.FriendlyName});
 
@@ -53,6 +59,9 @@ public static partial class Templates
 
         protected override string ProcessComponent(TypeMetadata.Component metadata) =>
             $"""
+                     /// <summary>
+                     /// Gets a <see cref="{metadata.FullyQualifiedName}"/> if the entity has one, otherwise returns null.
+                     /// </summary>
                      {(metadata.IsInternal ? "internal" : "public")} static global::{metadata.FullyQualifiedName}? TryGet{metadata.FriendlyName}(this global::Bang.Entities.Entity e)
                          => e.Has{metadata.FriendlyName}() ? e.Get{metadata.FriendlyName}() : null;
 
@@ -82,6 +91,9 @@ public static partial class Templates
                         : "";
 
                 builder.Append($$"""
+                                         /// <summary>
+                                         /// Adds or replaces the component of type <see cref="{{metadata.FullyQualifiedName}}" />.
+                                         /// </summary>
                                          {{(metadata.IsInternal ? "internal" : "public")}} static void Set{{metadata.FriendlyName}}(this global::Bang.Entities.Entity e{{parameterList}})
                                          {
                                              e.AddOrReplaceComponent(new global::{{metadata.FullyQualifiedName}}({{argumentList}}), global::Bang.Entities.{{ProjectPrefix}}ComponentTypes.{{metadata.FriendlyName}});
@@ -92,6 +104,9 @@ public static partial class Templates
             }
 
             builder.Append($$"""
+                             /// <summary>
+                             /// Adds or replaces the component of type <see cref="{{metadata.FullyQualifiedName}}" />.
+                             /// </summary>
                              {{(metadata.IsInternal ? "internal" : "public")}} static void Set{{metadata.FriendlyName}}(this global::Bang.Entities.Entity e, global::{{metadata.FullyQualifiedName}} component)
                              {
                                  e.AddOrReplaceComponent(component, global::Bang.Entities.{{ProjectPrefix}}ComponentTypes.{{metadata.FriendlyName}});
@@ -111,6 +126,9 @@ public static partial class Templates
 
         protected override string ProcessComponent(TypeMetadata.Component metadata) =>
             $$"""
+                      /// <summary>
+                      /// Adds or replaces the component of type <see cref="{{metadata.FullyQualifiedName}}" />.
+                      /// </summary>
                       {{(metadata.IsInternal ? "internal" : "public")}} static global::Bang.Entities.Entity With{{metadata.FriendlyName}}(this global::Bang.Entities.Entity e, global::{{metadata.FullyQualifiedName}} component)
                       {
                           e.AddOrReplaceComponent(component, global::Bang.Entities.{{ProjectPrefix}}ComponentTypes.{{metadata.FriendlyName}});
@@ -127,6 +145,9 @@ public static partial class Templates
 
         protected override string ProcessComponent(TypeMetadata.Component metadata) =>
             $"""
+                     /// <summary>
+                     /// Removes the component of type <see cref="{metadata.FullyQualifiedName}" />.
+                     /// </summary>
                      {(metadata.IsInternal ? "internal" : "public")} static bool Remove{metadata.FriendlyName}(this global::Bang.Entities.Entity e)
                          => e.RemoveComponent(global::Bang.Entities.{ProjectPrefix}ComponentTypes.{metadata.FriendlyName});
 
@@ -140,6 +161,9 @@ public static partial class Templates
 
         protected override string ProcessMessage(TypeMetadata.Message metadata) =>
             $"""
+                     /// <summary>
+                     /// Checks whether the entity has a message of type <see cref="{metadata.FullyQualifiedName}" /> or not.
+                     /// </summary>
                      {(metadata.IsInternal ? "internal" : "public")} static bool Has{metadata.TypeName}(this global::Bang.Entities.Entity e)
                          => e.HasComponent(global::Bang.Entities.{ProjectPrefix}MessageTypes.{metadata.FriendlyName});
 

--- a/src/Bang.Generator/Templating/Templates.MessageTypes.cs
+++ b/src/Bang.Generator/Templating/Templates.MessageTypes.cs
@@ -20,8 +20,12 @@ public static partial class Templates
 
         protected override string ProcessMessage(TypeMetadata.Message metadata)
             => $"""
+                
+                        /// <summary>
+                        /// Unique Id used for the lookup of messages with type <see cref="{metadata.FullyQualifiedName}"/>.
+                        /// </summary>
                         public const int {metadata.FriendlyName} = global::Bang.{ParentProjectPrefix}ComponentsLookup.{ParentProjectPrefix}NextLookupId + {metadata.Index};
-
+                
                 """;
     }
 }

--- a/src/Bang.Generator/Templating/Templates.cs
+++ b/src/Bang.Generator/Templating/Templates.cs
@@ -6,9 +6,11 @@ public static partial class Templates
         """
         namespace Bang.Entities
         {
+            /// <summary>
+            /// Collection of all ids for fetching components declared in this project.
+            /// </summary>
             public static class <project_prefix>ComponentTypes
-            {
-        <component_id_list>    }
+            {<component_id_list>    }
         }
         """;
 
@@ -16,9 +18,11 @@ public static partial class Templates
         """
         namespace Bang.Entities
         {
+            /// <summary>
+            /// Collection of all ids for fetching components declared in this project.
+            /// </summary>
             public static class <project_prefix>MessageTypes
-            {
-        <message_id_list>    }
+            {<message_id_list>    }
         }
         """;
 
@@ -26,6 +30,9 @@ public static partial class Templates
         """
         namespace Bang.Entities
         {
+            /// <summary>
+            /// Quality of life extensions for the components declared in this project.
+            /// </summary>
             public static class <project_prefix>EntityExtensions
             {
                 #region Component "Get" methods!
@@ -66,9 +73,18 @@ public static partial class Templates
 
         namespace Bang
         {
+            /// <summary>
+            /// Auto-generated implementation of <see cref="Bang.ComponentsLookup" /> for this project.
+            /// </summary>
             public class <project_prefix>ComponentsLookup : <parent_project_lookup>
             {
+                /// <summary>
+                /// First lookup id a <see cref="Bang.ComponentsLookup"/> implementation that inherits from this class must use.
+                /// </summary>
                 <component_count_const>
+                /// <summary>
+                /// Default constructor. This is only relevant for the internals of Bang, so you can ignore it.
+                /// </summary>
                 public <project_prefix>ComponentsLookup()
                 {
                     MessagesIndex = base.MessagesIndex.Concat(_messagesIndex).ToImmutableDictionary();

--- a/src/Bang/Entities/BangComponentTypes.cs
+++ b/src/Bang/Entities/BangComponentTypes.cs
@@ -1,9 +1,21 @@
 namespace Bang.Entities
 {
+    /// <summary>
+    /// Ids reserved for special Bang components.
+    /// </summary>
     public static class BangComponentTypes
     {
+        /// <summary>
+        /// Unique Id used for the lookup of components with type <see cref="Bang.StateMachines.IStateMachineComponent"/>.
+        /// </summary>
         public const int StateMachine = 0;
+        /// <summary>
+        /// Unique Id used for the lookup of components with type <see cref="Bang.Interactions.IInteractiveComponent"/>.
+        /// </summary>
         public const int Interactive = 1;
+        /// <summary>
+        /// Unique Id used for the lookup of components with type <see cref="Bang.Components.ITransformComponent"/>.
+        /// </summary>
         public const int Transform = 2;
     }
 }

--- a/src/Bang/Entities/Extensions.cs
+++ b/src/Bang/Entities/Extensions.cs
@@ -4,74 +4,131 @@ using Bang.StateMachines;
 
 namespace Bang.Entities
 {
+    /// <summary>
+    /// Quality of life extensions for the default components declared in Bang.
+    /// </summary>
     public static class Extensions
     {
+        /// <summary>
+        /// Gets a component of type <see cref="ITransformComponent"/>.
+        /// </summary>
         public static ITransformComponent GetTransform(this Entity e)
             => e.GetComponent<ITransformComponent>(BangComponentTypes.Transform);
 
+        /// <summary>
+        /// Checks whether this entity possesses a component of type <see cref="ITransformComponent"/> or not.
+        /// </summary>
         public static bool HasTransform(this Entity e)
             => e.HasComponent(BangComponentTypes.Transform);
 
+        /// <summary>
+        /// Gets a <see cref="ITransformComponent"/> if the entity has one, otherwise returns null.
+        /// </summary>
         public static ITransformComponent? TryGetTransform(this Entity e)
             => e.HasTransform() ? e.GetTransform() : null;
 
+        /// <summary>
+        /// Adds or replaces the component of type <see cref="ITransformComponent" />.
+        /// </summary>
         public static void SetTransform(this Entity e, ITransformComponent component)
         {
             e.AddOrReplaceComponent(component, BangComponentTypes.Transform);
         }
 
+        /// <summary>
+        /// Adds or replaces the component of type <see cref="ITransformComponent" />.
+        /// </summary>
         public static Entity WithTransform(this Entity e, ITransformComponent component)
         {
             e.AddOrReplaceComponent(component, BangComponentTypes.Transform);
             return e;
         }
 
+        /// <summary>
+        /// Removes the component of type <see cref="ITransformComponent" />.
+        /// </summary>
         public static bool RemoveTransform(this Entity e)
             => e.RemoveComponent(BangComponentTypes.Transform);
 
+        /// <summary>
+        /// Gets a component of type <see cref="IStateMachineComponent"/>.
+        /// </summary>
         public static IStateMachineComponent GetStateMachine(this Entity e)
             => e.GetComponent<IStateMachineComponent>(BangComponentTypes.StateMachine);
 
+        /// <summary>
+        /// Checks whether this entity possesses a component of type <see cref="IStateMachineComponent"/> or not.
+        /// </summary>
         public static bool HasStateMachine(this Entity e)
             => e.HasComponent(BangComponentTypes.StateMachine);
 
+        /// <summary>
+        /// Gets a <see cref="IStateMachineComponent"/> if the entity has one, otherwise returns null.
+        /// </summary>
         public static IStateMachineComponent? TryGetStateMachine(this Entity e)
             => e.HasStateMachine() ? e.GetStateMachine() : null;
 
+        /// <summary>
+        /// Adds or replaces the component of type <see cref="IStateMachineComponent" />.
+        /// </summary>
         public static void SetStateMachine(this Entity e, IStateMachineComponent component)
         {
             e.AddOrReplaceComponent(component, BangComponentTypes.StateMachine);
         }
 
+        /// <summary>
+        /// Adds or replaces the component of type <see cref="IStateMachineComponent" />.
+        /// </summary>
         public static Entity WithStateMachine(this Entity e, IStateMachineComponent component)
         {
             e.AddOrReplaceComponent(component, BangComponentTypes.StateMachine);
             return e;
         }
 
+        /// <summary>
+        /// Removes the component of type <see cref="IStateMachineComponent" />.
+        /// </summary>
         public static bool RemoveStateMachine(this Entity e)
             => e.RemoveComponent(BangComponentTypes.StateMachine);
 
+        /// <summary>
+        /// Gets a component of type <see cref="IInteractiveComponent"/>.
+        /// </summary>
         public static IInteractiveComponent GetInteractive(this Entity e)
             => e.GetComponent<IInteractiveComponent>(BangComponentTypes.Interactive);
 
+        /// <summary>
+        /// Checks whether this entity possesses a component of type <see cref="IInteractiveComponent"/> or not.
+        /// </summary>
         public static bool HasInteractive(this Entity e)
             => e.HasComponent(BangComponentTypes.Interactive);
 
+        /// <summary>
+        /// Gets a <see cref="IInteractiveComponent"/> if the entity has one, otherwise returns null.
+        /// </summary>
         public static IInteractiveComponent? TryGetInteractive(this Entity e)
             => e.HasInteractive() ? e.GetInteractive() : null;
 
+        /// <summary>
+        /// Adds or replaces the component of type <see cref="IInteractiveComponent" />.
+        /// </summary>
         public static void SetInteractive(this Entity e, IInteractiveComponent component)
         {
             e.AddOrReplaceComponent(component, BangComponentTypes.Interactive);
         }
 
+        /// <summary>
+        /// Adds or replaces the component of type <see cref="IInteractiveComponent" />.
+        /// </summary>
         public static Entity WithInteractive(this Entity e, IInteractiveComponent component)
         {
             e.AddOrReplaceComponent(component, BangComponentTypes.Interactive);
             return e;
         }
 
+        /// <summary>
+        /// Removes the component of type <see cref="IInteractiveComponent" />.
+        /// </summary>
         public static bool RemoveInteractive(this Entity e)
             => e.RemoveComponent(BangComponentTypes.Interactive);
     }


### PR DESCRIPTION
This fixes all build warnings for Bang after the analyzer PR wreaked havoc. This also ensures that Bang.Generator outputs code that does not emit warnings