### PR TITLE
🐛 Fix exception in attribute analyzers

### DIFF
--- a/src/Bang.Analyzers/Analyzers/AttributeAnalyzer.cs
+++ b/src/Bang.Analyzers/Analyzers/AttributeAnalyzer.cs
@@ -115,7 +115,7 @@ public sealed class AttributeAnalyzer : DiagnosticAnalyzer
         return context.SemanticModel
             .GetDeclaredSymbol(annotatedTypeNode)?
             .GetAttributes()
-            .Single(a => a.ApplicationSyntaxReference!.GetSyntax() == attributeSyntax);
+            .SingleOrDefault(a => a.ApplicationSyntaxReference!.GetSyntax() == attributeSyntax);
     }
 
     private static (INamedTypeSymbol, DiagnosticDescriptor)? GetInterfaceThatMustBeImplemented(


### PR DESCRIPTION
This fixes an exception inside the analyzer. This is an edge case that happens when there's an annotation for a property that is also a constructor parameter for a record. Since this analyzer should not be used for records anyways, it's safe to fail silently rather than with a warning.