### PR TITLE
⏰ Cron job for pre-releasing

### DIFF
--- a/.github/workflows/cron_pre_release.yaml
+++ b/.github/workflows/cron_pre_release.yaml
@@ -1,0 +1,31 @@
+name: Publish Pre-Release
+on:
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  generate-version-name:
+    name: Generate version name
+    runs-on: ubuntu-latest
+    outputs:
+      dev-version: ${{ steps.generate-dev-version.outputs.dev-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Calculate build version from Git
+        id: generate-dev-version
+        run: |
+          tag=$(git describe --tags --abbrev=0)
+          commitCount=$(git rev-list --count main)
+          version="$tag-$commitCount-dev"
+          echo "dev-version=$version" >> "$GITHUB_OUTPUT"
+
+  pre-release:
+    name: Build for Linux
+    needs: generate-version-name
+    uses: ./.github/workflows/release.yaml
+    with:
+      release-version: ${{ needs.generate-version-name.outputs.dev-version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,11 @@
 name: Publish Release
+
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      release-version:
+        required: true
+        type: string
 
 jobs:
   release:
@@ -32,9 +36,7 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          tag=$(git describe --tags --abbrev=0)
-
-          release_name="bang-$tag-${{ matrix.target }}"
+          release_name="bang-${{ inputs.release-version }}}-${{ matrix.target }}"
 
           # Build everything
           dotnet publish --runtime "${{ matrix.target }}" -c Release -o "$release_name" --no-self-contained

--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -1,0 +1,29 @@
+name: Publish Release
+on:
+  release:
+    types: [published]
+
+jobs:
+  generate-version-name:
+    name: Generate version name
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.generate-version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Calculate build version from Git
+        id: generate-version
+        run: |
+          tag=$(git describe --tags --abbrev=0)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  pre-release:
+    name: Build for Linux
+    needs: generate-version-name
+    uses: ./.github/workflows/release.yaml
+    with:
+      release-version: ${{ needs.generate-version-name.outputs.version }}


### PR DESCRIPTION
This creates a Cron job for pushing new versions to Nuget with the version `{latest}-{commitCount}-dev` every midnight.

If we ever switch to a protected main branch with mandatory PRs (something for the far future when things are stable) we can simply swap this to run on every commit to main instead.

This is part of the effort to make Murder usable via NuGet. Having early versions creatable on demand can speed-up the workflow of using Bang as a package inside murder, which enables further exploration of using murder as a package.