### PR TITLE
⏱️ Fix Cronjob releases

### DIFF
--- a/.github/workflows/cron_pre_release.yaml
+++ b/.github/workflows/cron_pre_release.yaml
@@ -28,4 +28,6 @@ jobs:
     needs: generate-version-name
     uses: ./.github/workflows/release.yaml
     with:
+      is-pre-release: true
       release-version: ${{ needs.generate-version-name.outputs.dev-version }}
+    secrets:

--- a/.github/workflows/cron_pre_release.yaml
+++ b/.github/workflows/cron_pre_release.yaml
@@ -31,3 +31,4 @@ jobs:
       is-pre-release: true
       release-version: ${{ needs.generate-version-name.outputs.dev-version }}
     secrets:
+      nuget-token: ${{secrets.NUGET_TOKEN}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,10 +6,14 @@ on:
       release-version:
         required: true
         type: string
+      is-pre-release:
+        required: true
+        type: boolean
 
 jobs:
   release:
-    name: 📪 Release
+    name: 📪 Release to GitHub
+    if: ${{!inputs.is-pre-release}}
     strategy:
       matrix:
         kind: ['linux', 'windows', 'macOS']

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,9 @@ on:
       is-pre-release:
         required: true
         type: boolean
+    secrets:
+      nuget-token:
+        required: true
 
 jobs:
   release:
@@ -64,7 +67,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   pack:
-    name: 📦 Pack and publish
+    name: 📦 Pack and publish to NuGet
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -81,7 +84,7 @@ jobs:
       - name: Pack and push
         run: |
             dotnet build -c Release
-            dotnet pack -c Release
-            dotnet nuget push ./src/**/bin/Release/Murder.Bang.*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate --api-key ${NUGET_TOKEN}
+            dotnet pack -c Release /p:Version=${{inputs.release-version}}
+            dotnet nuget push ./src/**/bin/Release/Murder.Bang.*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate --api-key ${nuget-token}
         env:
-          NUGET_TOKEN: ${{secrets.NUGET_TOKEN}}
+          nuget-token: ${{secrets.nuget-token}}

--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -29,3 +29,4 @@ jobs:
       is-pre-release: false
       release-version: ${{ needs.generate-version-name.outputs.version }}
     secrets:
+      nuget-token: ${{secrets.NUGET_TOKEN}}

--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -26,4 +26,6 @@ jobs:
     needs: generate-version-name
     uses: ./.github/workflows/release.yaml
     with:
+      is-pre-release: false
       release-version: ${{ needs.generate-version-name.outputs.version }}
+    secrets:


### PR DESCRIPTION
These had two problems:

- Publish was trying to publish (incorrectly) to GitHub
- Secrets weren't being properly propagated to the sub workflow

These should be fixed now (to the best of my abilities to diagnose without access)