### PR TITLE
🔢 Count commits from HEAD

### DIFF
--- a/.github/workflows/cron_pre_release.yaml
+++ b/.github/workflows/cron_pre_release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Pack and push
         run: |
           tag=$(git describe --tags --abbrev=0)
-          version="$tag-$(git rev-list --count main)-dev"
+          version="$tag-$(git rev-list --count HEAD)-dev"
           dotnet build -c Release
           dotnet pack -c Release /p:Version=$version
           dotnet nuget push ./src/**/bin/Release/Murder.Bang.*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate --api-key ${NUGET_TOKEN}


### PR DESCRIPTION
This will count the commits from HEAD instead of some branch to make it simpler for the checkout action