### PR TITLE
🧠 Default implementations for update systems

### DIFF
--- a/src/Bang/Systems/IFixedUpdateSystem.cs
+++ b/src/Bang/Systems/IFixedUpdateSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Bang.Contexts;
+using Bang.Entities;
 
 namespace Bang.Systems
 {
@@ -11,6 +12,29 @@ namespace Bang.Systems
         /// Update calls that will be called in fixed intervals.
         /// </summary>
         /// <param name="context">Context that will filter the entities.</param>
-        public abstract void FixedUpdate(Context context);
+        public void FixedUpdate(Context context);
+    }
+
+    /// <summary>
+    /// Simple implementation of <see cref="IFixedUpdateSystem"/> that calls
+    /// <see cref="PerformFixedUpdate"/> for each entity matching the filter.
+    /// </summary>
+    public abstract class SimpleFixedUpdateSystem : IFixedUpdateSystem
+    {
+        /// <inheritdoc />
+        public void FixedUpdate(Context context)
+        {
+            foreach (var entity in context.Entities)
+            {
+                PerformFixedUpdate(entity, context);
+            }
+        }
+
+        /// <summary>
+        /// Called on a set interval for every entity that matches the <see cref="FilterAttribute" />.
+        /// </summary>
+        /// <param name="entity">Entity being processed.</param>
+        /// <param name="context">Context for the world.</param>
+        protected abstract void PerformFixedUpdate(Entity entity, Context context);
     }
 }

--- a/src/Bang/Systems/IUpdateSystem.cs
+++ b/src/Bang/Systems/IUpdateSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Bang.Contexts;
+using Bang.Entities;
 
 namespace Bang.Systems
 {
@@ -10,6 +11,29 @@ namespace Bang.Systems
         /// <summary>
         /// Update method. Called once each frame.
         /// </summary>
-        public abstract void Update(Context context);
+        public void Update(Context context);
+    }
+
+    /// <summary>
+    /// Simple implementation of <see cref="IUpdateSystem"/> that calls
+    /// <see cref="PerformUpdate"/> for each entity matching the filter.
+    /// </summary>
+    public abstract class SimpleUpdateSystem : IUpdateSystem
+    {
+        /// <inheritdoc />
+        public void Update(Context context)
+        {
+            foreach (var entity in context.Entities)
+            {
+                PerformUpdate(entity, context);
+            }
+        }
+
+        /// <summary>
+        /// Called each frame for every entity that matches the <see cref="FilterAttribute" />.
+        /// </summary>
+        /// <param name="entity">Entity being processed.</param>
+        /// <param name="context">Context for the world.</param>
+        protected abstract void PerformUpdate(Entity entity, Context context);
     }
 }


### PR DESCRIPTION
This provides a built-in way of removing one level of nesting if your system follows the common pattern of simply performing some operations for every entity that matches your filter. This pattern shows up mostly on these two interfaces, which is why I'm providing defaults for both