### PR TITLE
🍝 Fix Copypasta in message template

### DIFF
--- a/src/Bang.Generator/Templating/Templates.EntityExtensions.cs
+++ b/src/Bang.Generator/Templating/Templates.EntityExtensions.cs
@@ -18,7 +18,7 @@ public static partial class Templates
             new ComponentWithSubstitution(),
             new ComponentRemoveSubstitution(),
             new MessageHasSubstitution(),
-            new MessageSetSubstitution(),
+            new MessageSendSubstitution(),
             new MessageRemoveSubstitution()
         )
     );
@@ -173,9 +173,9 @@ public static partial class Templates
              """;
     }
 
-    private sealed class MessageSetSubstitution : TemplateSubstitution
+    private sealed class MessageSendSubstitution : TemplateSubstitution
     {
-        public MessageSetSubstitution() : base("<messages_set>") { }
+        public MessageSendSubstitution() : base("<messages_send>") { }
 
         protected override string ProcessMessage(TypeMetadata.Message metadata)
         {

--- a/src/Bang.Generator/Templating/Templates.cs
+++ b/src/Bang.Generator/Templating/Templates.cs
@@ -63,11 +63,11 @@ public static partial class Templates
 
         <messages_has>        #endregion
         
-                #region Message "Set" checkers!
+                #region Message "Send" methods!
         
-        <messages_set>        #endregion
+        <messages_send>        #endregion
         
-                #region Message "Remove" checkers!
+                #region Message "Remove" methods!
         
         <messages_remove>        #endregion
             }


### PR DESCRIPTION
Noticed a tiny typo there, likely caused when copy pasting. This fixes it.